### PR TITLE
A parameter `conditional` is added to `dviSim()`.

### DIFF
--- a/R/dviSim.R
+++ b/R/dviSim.R
@@ -9,14 +9,21 @@
 #'   the typed members of the input.
 #' @param truth A named vector of the format `c(vic1 = mis1, vic2 = mis2, ...)`.
 #' @param seed An integer seed for the random number generator.
-#' @param conditional A logical. If `TRUE`, references are not simulated.
+#' @param conditional A logical, by default FALSE. If TRUE, references are kept
+#'   unchanged, while the missing persons are simulated conditional on these.
 #' @param verbose A logical.
 #'
-#' @return A `dviData` object similar to the input.
+#' @return A `dviData` object similar to the input, but with new genotypes.
 #'
 #' @seealso [forrel::profileSim()].
 #'
 #' @examples
+#'
+#' # Simulate refs and missing
+#' ex = dviSim(example2, truth = c(V1 = "M1", V2 = "M2"))
+#' plotDVI(ex, marker = 1)
+#'
+#' # Simulate missing conditional on existing refs
 #' ex = dviSim(example2, truth = c(V1 = "M1", V2 = "M2"), conditional = TRUE)
 #' plotDVI(ex, marker = 1)
 #'

--- a/R/dviSim.R
+++ b/R/dviSim.R
@@ -9,6 +9,7 @@
 #'   the typed members of the input.
 #' @param truth A named vector of the format `c(vic1 = mis1, vic2 = mis2, ...)`.
 #' @param seed An integer seed for the random number generator.
+#' @param conditional A logical. If `TRUE`, references are not simulated.
 #' @param verbose A logical.
 #'
 #' @return A `dviData` object similar to the input.
@@ -16,12 +17,12 @@
 #' @seealso [forrel::profileSim()].
 #'
 #' @examples
-#' ex = dviSim(example2, truth = c(V1 = "M1", V2 = "M2"))
+#' ex = dviSim(example2, truth = c(V1 = "M1", V2 = "M2"), conditional = TRUE)
 #' plotDVI(ex, marker = 1)
 #'
 #' @export
 dviSim = function(dvi, refs = typedMembers(dvi$am), truth = NULL, seed = NULL, 
-                  verbose = FALSE){
+                  conditional = FALSE, verbose = FALSE){
   
   dvi = consolidateDVI(dvi)
   
@@ -41,14 +42,20 @@ dviSim = function(dvi, refs = typedMembers(dvi$am), truth = NULL, seed = NULL,
   if(!is.null(seed))
     set.seed(seed)
   
-  # Remove existing genotypes
+  # Remove existing genotypes in pm
   pm = dvi$pm |> setAlleles(alleles = 0)
-  am = dvi$am |> setAlleles(alleles = 0)
   missing = dvi$missing
   
-  # Simulate profiles of references and missing persons
-  amSim = profileSim(am, ids = c(refs, missing))
-  
+  # Simulate profiles of missing persons and also of references if conditional = FALSE
+  if(conditional){
+    am = dvi$am |> setAlleles(alleles = 0, ids = missing)
+    amSim = profileSim(am, ids = missing)
+  }
+  else{
+    am = dvi$am |> setAlleles(alleles = 0)
+    amSim = profileSim(am, ids = c(refs, missing))
+  }
+    
   # Transfer to PM according to `truth`
   pmSim = transferMarkers(from = amSim, to = pm, idsFrom = truth,
                           idsTo = names(truth), erase = FALSE) 

--- a/dvir.Rproj
+++ b/dvir.Rproj
@@ -15,4 +15,5 @@ LaTeX: pdfLaTeX
 BuildType: Package
 PackageUseDevtools: Yes
 PackageInstallArgs: --no-multiarch --with-keep.source
+PackageCheckArgs: --as-cran --run-donttest
 PackageRoxygenize: rd,collate,namespace,vignette

--- a/man/dviSim.Rd
+++ b/man/dviSim.Rd
@@ -9,6 +9,7 @@ dviSim(
   refs = typedMembers(dvi$am),
   truth = NULL,
   seed = NULL,
+  conditional = FALSE,
   verbose = FALSE
 )
 }
@@ -22,6 +23,8 @@ the typed members of the input.}
 
 \item{seed}{An integer seed for the random number generator.}
 
+\item{conditional}{A logical. If \code{TRUE}, references are not simulated.}
+
 \item{verbose}{A logical.}
 }
 \value{
@@ -33,7 +36,7 @@ transfers to the PM singletons according to the indicated matching. Remaining
 victims are simulated as unrelated.
 }
 \examples{
-ex = dviSim(example2, truth = c(V1 = "M1", V2 = "M2"))
+ex = dviSim(example2, truth = c(V1 = "M1", V2 = "M2"), conditional = TRUE)
 plotDVI(ex, marker = 1)
 
 }

--- a/man/dviSim.Rd
+++ b/man/dviSim.Rd
@@ -23,12 +23,13 @@ the typed members of the input.}
 
 \item{seed}{An integer seed for the random number generator.}
 
-\item{conditional}{A logical. If \code{TRUE}, references are not simulated.}
+\item{conditional}{A logical, by default FALSE. If TRUE, references are kept
+unchanged, while the missing persons are simulated conditional on these.}
 
 \item{verbose}{A logical.}
 }
 \value{
-A \code{dviData} object similar to the input.
+A \code{dviData} object similar to the input, but with new genotypes.
 }
 \description{
 Simulates genotypes for the references and missing persons in each AM family,
@@ -36,6 +37,12 @@ transfers to the PM singletons according to the indicated matching. Remaining
 victims are simulated as unrelated.
 }
 \examples{
+
+# Simulate refs and missing
+ex = dviSim(example2, truth = c(V1 = "M1", V2 = "M2"))
+plotDVI(ex, marker = 1)
+
+# Simulate missing conditional on existing refs
 ex = dviSim(example2, truth = c(V1 = "M1", V2 = "M2"), conditional = TRUE)
 plotDVI(ex, marker = 1)
 


### PR DESCRIPTION
If  `conditional = TRUE`, references are not simulated. If `conditional = FALSE`, the default, references are simulated as before.
Examples:
``` r
library(dvir)
#> Loading required package: pedtools
ex = dviSim(example2, truth = c(V1 = "M1", V2 = "M2", V3 = "M3"), conditional = T)
plotDVI(ex, marker = 1)
```

![](https://i.imgur.com/bHJg1M4.png)<!-- -->

``` r
ex = dviSim(example2, truth = c(V1 = "M1", V2 = "M2", V3 = "M3"), conditional = F)
plotDVI(ex, marker = 1) 
```

![](https://i.imgur.com/V5Iifjg.png)<!-- -->

``` r
Ȁ
#> Error in eval(expr, envir, enclos): object 'Ȁ' not found
```

<sup>Created on 2023-11-20 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>
