### PR TITLE
`dviSim()` extended to allow for N simulations

### DIFF
--- a/R/dviSim.R
+++ b/R/dviSim.R
@@ -5,75 +5,97 @@
 #' victims are simulated as unrelated.
 #'
 #' @param dvi A `dviData` object.
+#' @param N	The number of complete simulations to be performed.
 #' @param refs A character with names of all reference individuals. By default,
 #'   the typed members of the input.
 #' @param truth A named vector of the format `c(vic1 = mis1, vic2 = mis2, ...)`.
 #' @param seed An integer seed for the random number generator.
 #' @param conditional A logical, by default FALSE. If TRUE, references are kept
 #'   unchanged, while the missing persons are simulated conditional on these.
+#' @param simplify1	A logical, by default TRUE, removing the outer list layer 
+#'   when N = 1. See Value.
 #' @param verbose A logical.
 #'
-#' @return A `dviData` object similar to the input, but with new genotypes.
+#' @return If `N = 1`, a `dviData` object similar to the input, but with new genotypes
+#'   for the pm samples. If `N > 1`, a list of `dviData` objects. 
 #'
 #' @seealso [forrel::profileSim()].
 #'
 #' @examples
 #'
-#' # Simulate refs and missing
-#' ex = dviSim(example2, truth = c(V1 = "M1", V2 = "M2"))
+#' # Simulate refs and missing once and plot:
+#' ex = dviSim(example2, N = 1, truth = c(V1 = "M1", V2 = "M2", V3 = "M3"))
 #' plotDVI(ex, marker = 1)
 #'
-#' # Simulate missing conditional on existing refs
-#' ex = dviSim(example2, truth = c(V1 = "M1", V2 = "M2"), conditional = TRUE)
-#' plotDVI(ex, marker = 1)
+#' # Two simulations and plot for the first
+#' ex = dviSim(example2, N = 2, truth = c(V1 = "M1", V2 = "M2", V3 = "M3"), 
+#'             seed = 1729)
+#' plotDVI(ex[[1]], marker = 1)
+#' 
 #'
 #' @export
-dviSim = function(dvi, refs = typedMembers(dvi$am), truth = NULL, seed = NULL, 
-                  conditional = FALSE, verbose = FALSE){
-  
+dviSim = function(dvi, N = 1, refs = typedMembers(dvi$am), truth = NULL, 
+                  seed = NULL, conditional = FALSE, simplify1 = TRUE,
+                  verbose = FALSE) {
   dvi = consolidateDVI(dvi)
   
   labsAM = labels(dvi$am) |> unlist(use.names = FALSE)
-  if(!all(refs %in% labsAM))
+  if (!all(refs %in% labsAM)) {
     stop2("Unknown reference ID of reference: ", setdiff(refs, labsAM))
+  }
   
-  if(any(refs %in% dvi$missing))
+  if (any(refs %in% dvi$missing)) {
     stop2("Missing person cannot be a reference: ", intersect(refs, dvi$missing))
+  }
   
-  if(!all(truth %in% dvi$missing))
+  if (!all(truth %in% dvi$missing)) {
     stop2("Unknown missing person ID: ", setdiff(truth, dvi$missing))
+  }
   
-  if(!all(names(truth) %in% names(dvi$pm)))
+  if (!all(names(truth) %in% names(dvi$pm))) {
     stop2("Unknown victim ID: ", setdiff(names(truth), names(dvi$pm)))
+  }
   
-  if(!is.null(seed))
+  if (!is.null(seed)) {
     set.seed(seed)
+  }
   
   # Remove existing genotypes in pm
   pm = dvi$pm |> setAlleles(alleles = 0)
   missing = dvi$missing
   
   # Simulate profiles of missing persons and also of references if conditional = FALSE
-  if(conditional){
+  if (conditional) {
     am = dvi$am |> setAlleles(alleles = 0, ids = missing)
-    amSim = profileSim(am, ids = missing)
-  }
-  else{
+    amSim = profileSim(am, N = N, ids = missing, simplify1 = FALSE, 
+                       verbose = verbose)
+  } else {
     am = dvi$am |> setAlleles(alleles = 0)
-    amSim = profileSim(am, ids = c(refs, missing))
+    amSim = profileSim(am, N = N, ids = c(refs, missing), simplify1 = FALSE, 
+                       verbose = verbose)
   }
-    
+  
   # Transfer to PM according to `truth`
-  pmSim = transferMarkers(from = amSim, to = pm, idsFrom = truth,
-                          idsTo = names(truth), erase = FALSE) 
+  pmSim = lapply(amSim, function(z) {
+    transferMarkers(
+      from = z, to = pm, idsFrom = truth, idsTo = names(truth), erase = FALSE
+      )})
+  
+  # Erase genotypes of missing
+  amSim = lapply(amSim, function(z) setAlleles(z, ids = missing, alleles = 0))
   
   # Simulate the remaining victims
   remVics = setdiff(names(pm), names(truth))
-  if(length(remVics))
-    pmSim[remVics] = forrel::profileSim(pm[remVics])
+  if (length(remVics)) 
+    pmSim = lapply(pmSim, function(z) forrel::profileSim(z, ids = remVics))
   
-  # Erase genotypes of missing
-  amSim = setAlleles(amSim, ids = missing, alleles = 0)
+  # Collect the list of dvi data objects  
+  dviDataSimulated = lapply(seq_len(N), function(i) {
+    dviData(pmSim[[i]], amSim[[i]], missing)
+    })
+ 
+  if (simplify1 && N == 1) 
+    dviDataSimulated = dviDataSimulated[[1]]
   
-  dviData(pmSim, amSim, missing)
+  dviDataSimulated
 }

--- a/man/dviSim.Rd
+++ b/man/dviSim.Rd
@@ -6,15 +6,19 @@
 \usage{
 dviSim(
   dvi,
+  N = 1,
   refs = typedMembers(dvi$am),
   truth = NULL,
   seed = NULL,
   conditional = FALSE,
+  simplify1 = TRUE,
   verbose = FALSE
 )
 }
 \arguments{
 \item{dvi}{A \code{dviData} object.}
+
+\item{N}{The number of complete simulations to be performed.}
 
 \item{refs}{A character with names of all reference individuals. By default,
 the typed members of the input.}
@@ -26,10 +30,14 @@ the typed members of the input.}
 \item{conditional}{A logical, by default FALSE. If TRUE, references are kept
 unchanged, while the missing persons are simulated conditional on these.}
 
+\item{simplify1}{A logical, by default TRUE, removing the outer list layer
+when N = 1. See Value.}
+
 \item{verbose}{A logical.}
 }
 \value{
-A \code{dviData} object similar to the input, but with new genotypes.
+If \code{N = 1}, a \code{dviData} object similar to the input, but with new genotypes
+for the pm samples. If \code{N > 1}, a list of \code{dviData} objects.
 }
 \description{
 Simulates genotypes for the references and missing persons in each AM family,
@@ -38,13 +46,15 @@ victims are simulated as unrelated.
 }
 \examples{
 
-# Simulate refs and missing
-ex = dviSim(example2, truth = c(V1 = "M1", V2 = "M2"))
+# Simulate refs and missing once and plot:
+ex = dviSim(example2, N = 1, truth = c(V1 = "M1", V2 = "M2", V3 = "M3"))
 plotDVI(ex, marker = 1)
 
-# Simulate missing conditional on existing refs
-ex = dviSim(example2, truth = c(V1 = "M1", V2 = "M2"), conditional = TRUE)
-plotDVI(ex, marker = 1)
+# Two simulations and plot for the first
+ex = dviSim(example2, N = 2, truth = c(V1 = "M1", V2 = "M2", V3 = "M3"), 
+            seed = 1729)
+plotDVI(ex[[1]], marker = 1)
+
 
 }
 \seealso{

--- a/man/dviSim.Rd
+++ b/man/dviSim.Rd
@@ -20,8 +20,9 @@ dviSim(
 
 \item{N}{The number of complete simulations to be performed.}
 
-\item{refs}{A character with names of all reference individuals. By default,
-the typed members of the input.}
+\item{refs}{A character indicating reference individuals. By default, the
+typed members of the input. If \code{conditional = TRUE}, the \code{refs} should be a
+subset of the typed members, and the simulations are conditional on these.}
 
 \item{truth}{A named vector of the format \code{c(vic1 = mis1, vic2 = mis2, ...)}.}
 
@@ -36,8 +37,8 @@ when N = 1. See Value.}
 \item{verbose}{A logical.}
 }
 \value{
-If \code{N = 1}, a \code{dviData} object similar to the input, but with new genotypes
-for the pm samples. If \code{N > 1}, a list of \code{dviData} objects.
+If \code{N = 1}, a \code{dviData} object similar to the input, but with new
+genotypes for the pm samples. If \code{N > 1}, a list of \code{dviData} objects.
 }
 \description{
 Simulates genotypes for the references and missing persons in each AM family,
@@ -51,7 +52,7 @@ ex = dviSim(example2, N = 1, truth = c(V1 = "M1", V2 = "M2", V3 = "M3"))
 plotDVI(ex, marker = 1)
 
 # Two simulations and plot for the first
-ex = dviSim(example2, N = 2, truth = c(V1 = "M1", V2 = "M2", V3 = "M3"), 
+ex = dviSim(example2, N = 2, truth = c(V1 = "M1", V2 = "M2", V3 = "M3"),
             seed = 1729)
 plotDVI(ex[[1]], marker = 1)
 


### PR DESCRIPTION
Please consider the extension exemplified below:
``` r
library(dvir, quietly = T)
s = dviSim(planecrash, truth = c(V1 = "M1"), N = 5, seed = 1729)
lapply(s, function(z) jointDVI(z, verbose = F)[1,])
#> [[1]]
#>   V1 V2 V3 V4 V5 V6 V7 V8    loglik       LR posterior
#> 1 M1  *  * M5  *  *  *  * -502.2931 24624918 0.9834212
#> 
#> [[2]]
#>   V1 V2 V3 V4 V5 V6 V7 V8    loglik       LR posterior
#> 1 M1  *  *  *  *  *  *  * -501.4423 22611.36 0.8814802
#> 
#> [[3]]
#>   V1 V2 V3 V4 V5 V6 V7 V8    loglik       LR posterior
#> 1 M1  *  *  *  *  *  *  * -512.1283 76365.08 0.7779288
#> 
#> [[4]]
#>   V1 V2 V3 V4 V5 V6 V7 V8    loglik       LR posterior
#> 1 M1  *  *  *  *  *  *  * -504.3338 861791.1 0.8823412
#> 
#> [[5]]
#>   V1 V2 V3 V4 V5 V6 V7 V8    loglik       LR posterior
#> 1 M1  *  *  *  *  *  *  * -558.7541 1464.118 0.6244145
```

<sup>Created on 2023-11-22 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>
